### PR TITLE
Update `format-suggest.yaml` to work with forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Development version
 
+- `format-suggest.yaml` now works as expected on pull requests originating from a fork.
+
+- The example workflows, `format-check.yaml` and `format-suggest.yaml`, now pin to explicit SHAs of their dependencies, limiting the possibility for vulnerabilities.
+
 # `v1.0.0` (2025-04-28)
 
 - First release!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,9 @@ When you release a new minor or patch release, you also update the major release
     -   It should already be pointing at the sliding `vX` tag
 
     -   Copy over CHANGELOG bullets for this patch or minor release into the release notes
+
+-   Update the SHAs in the `examples/` workflows
+
+    -   Update the pinned `posit-dev/setup-air` SHA to the latest commit
+
+    -   Update the pinned SHAs for other dependencies as you see fit

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ This runs `air format . --check` on every push to `main` and on every pull reque
 This is a very simple action that fails if any files would be reformatted.
 When this happens, reformat locally using `air format .` or the `Air: Format Workspace Folder` command in VS Code or Positron, and commit and push the results.
 
+### Security
+
+For an additional layer of security, the example actions pin the precise SHAs of the actions they utilize, like:
+
+``` yaml
+- name: Install
+  uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1
+```
+
+This is a tradeoff.
+You must now update this SHA to inherit bug fixes and updates, which you would otherwise get automatically from the sliding `v1` tag.
+However, you are also insulated from potential vulnerabilities, such as if malicious code is merged into the `posit-dev/setup-air` action itself.
+
+To easily update to the latest SHAs, just rerun the `usethis::use_github_action()` call from above.
+
 ## Customization
 
 In the following subsections, we explore a variety of ways to customize `posit-dev/setup-air`.

--- a/examples/format-check.yaml
+++ b/examples/format-check.yaml
@@ -1,4 +1,5 @@
 # Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
+
 on:
   push:
     branches: [main, master]
@@ -13,10 +14,10 @@ jobs:
     name: format-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install
-        uses: posit-dev/setup-air@v1
+        uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1
 
       - name: Check
         run: air format . --check

--- a/examples/format-suggest.yaml
+++ b/examples/format-suggest.yaml
@@ -1,28 +1,45 @@
 # Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
+
 on:
-  pull_request:
+  # Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
+  # privileges, otherwise we can't set `pull-requests: write` when the pull
+  # request comes from a fork, which is our main use case (external contributors).
+  #
+  # `pull_request_target` runs in the context of the target branch (`main`, usually),
+  # rather than in the context of the pull request like `pull_request` does. Due
+  # to this, we must explicitly checkout `ref: ${{ github.event.pull_request.head.sha }}`.
+  # This is typically frowned upon by GitHub, as it exposes you to potentially running
+  # untrusted code in a context where you have elevated privileges, but they explicitly
+  # call out the use case of reformatting and committing back / commenting on the PR
+  # as a situation that should be safe (because we aren't actually running the untrusted
+  # code, we are just treating it as passive data).
+  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  pull_request_target:
 
 name: format-suggest.yaml
-
-permissions: read-all
 
 jobs:
   format-suggest:
     name: format-suggest
     runs-on: ubuntu-latest
+
     permissions:
+      # Required to push suggestion comments to the PR
       pull-requests: write
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install
-        uses: posit-dev/setup-air@v1
+        uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1
 
       - name: Format
         run: air format .
 
       - name: Suggest
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@4747dbc9f9e37adba0943e681cc20db466642158 # v1
         with:
           level: error
           fail_level: error


### PR DESCRIPTION
The main use case of `format-suggest.yaml` is to give external contributors not using Air a good experience when they submit a PR that requires some formatting tweaks (think, tidy dev day).

In my testing, `format-suggest.yaml` was working fine because I was creating PRs in repos I owned.

When you create a PR originating from a fork, `pull_request` has _less privileges_ than when you create a PR as a maintainer. In particular, you don't have write access to be able to push comments back to the pull request.

GitHub introduced `pull_request_target`, which _does_ have elevated privileges, but must be used extremely carefully. By default, for safety, it checks out the "target", which is typically `main`. It does this so you don't accidentally run untrusted code coming from some external PR in your CI, possibly exposing secrets.

You can override `actions/checkout` with `ref: ${{ github.event.pull_request.head.sha }}` to check out the HEAD SHA of the pull request it is coming from, rather than checking out `main`. However, this is exactly what GitHub tries to get you to avoid doing, because typically you are _running_ the code from the pull request in some way, and having write access when you are running unsafe code is a security risk.

That said, they make an explicit exemption for our particular use case in [this blog post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) - checking out the pull request HEAD, treating it as "passive data", running a formatter over it, and using `pull_request_target`'s privileges to either commit back or push comments back to the PR.

For an additional layer of security, I've also pinned the SHAs of each action dependency we have, something that is becoming more common in the actions ecosystem after a few people got burned by sliding tags and malicious actors.

Overall I feel pretty good about the level of security here.